### PR TITLE
make it compatible with keras 2.2.2

### DIFF
--- a/mobilenets.py
+++ b/mobilenets.py
@@ -66,7 +66,10 @@ from keras.utils import conv_utils
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
 from keras.engine import InputSpec
-from keras.applications.imagenet_utils import _obtain_input_shape
+try:
+    from keras.applications.imagenet_utils import _obtain_input_shape
+except ImportError:
+    from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.applications.inception_v3 import preprocess_input
 from keras.applications.imagenet_utils import decode_predictions
 from keras import backend as K


### PR DESCRIPTION
`from keras.applications.imagenet_utils import _obtain_input_shape` will fail in keras 2.2.2, this PR makes it compatible with keras 2.2.2